### PR TITLE
Filename extension and reduce window

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Architecture: all
 Depends: ${misc:Depends}, ${python:Depends},
 	python,
 	python-gi,
-	python-cairo,
+	python-gi-cairo,
 	python-pil,
 	gir1.2-gtk-3.0,
 	gir1.2-gdkpixbuf-2.0,

--- a/src/pdf-tools/reducedialog.py
+++ b/src/pdf-tools/reducedialog.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import gi
+try:
+    gi.require_version('Gtk', '3.0')
+except Exception as e:
+    print(e)
+    exit(1)
+from gi.repository import Gtk
+import comun
+from comun import _
+
+class ReduceDialog(Gtk.Dialog):
+    def __init__(self, title, window):
+        Gtk.Dialog.__init__(
+            self,
+            title,
+            window,
+            Gtk.DialogFlags.MODAL |
+            Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            (Gtk.STOCK_OK, Gtk.ResponseType.ACCEPT,
+             Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL))
+        self.set_size_request(200, 150)
+        self.set_resizable(False)
+        self.set_icon_from_file(comun.ICON)
+        self.set_default_response(Gtk.ResponseType.ACCEPT)
+        self.connect('destroy', self.close_application)
+        vbox0 = Gtk.VBox(spacing=5)
+        vbox0.set_border_width(5)
+        self.get_content_area().add(vbox0)
+
+        frame1 = Gtk.Frame()
+        vbox0.add(frame1)
+
+        grid = Gtk.Grid()
+        grid.set_row_spacing(10)
+        grid.set_column_spacing(10)
+        grid.set_margin_bottom(10)
+        grid.set_margin_left(10)
+        grid.set_margin_right(10)
+        grid.set_margin_top(10)
+        frame1.add(grid)
+
+        label1 = Gtk.Label(_('Image resolution') + ':')
+        label1.set_alignment(0, .5)
+        grid.attach(label1, 0, 0, 1, 1)
+
+        label2 = Gtk.Label(_('Append to file') + ':')
+        label2.set_alignment(0, .5)
+        grid.attach(label2, 0, 1, 1, 1)
+
+        self.dpi_entry = Gtk.Entry()
+        self.dpi_entry.set_tooltip_text(_('Set dpi to reduce file'))
+        self.dpi_entry.set_text('100')
+        grid.attach(self.dpi_entry, 1, 0, 1, 1)
+
+        self.dpi_entry.set_activates_default(True)
+        self.dpi_entry.grab_focus()
+
+        self.append_entry = Gtk.Entry()
+        self.append_entry.set_tooltip_text(_('Append to file to create output filename'))
+        self.append_entry.set_text('_reduced')
+        grid.attach(self.append_entry, 1, 1, 1, 1)
+
+        self.show_all()
+
+    def get_dpi(self):
+        return self.dpi_entry.get_text()
+
+    def get_append(self):
+        return self.append_entry.get_text()
+
+    def close_application(self, widget):
+        self.hide()
+
+if __name__ == '__main__':
+    dialog = ReduceDialog('Test', None)
+    dialog.run()

--- a/src/pdf-tools/tools.py
+++ b/src/pdf-tools/tools.py
@@ -258,9 +258,9 @@ def create_from_images(file_out, images, width=1189, height=1682, margin=0):
     os.remove(temp_pdf)
 
 
-def reduce_pdf(file_in):
+def reduce_pdf(file_in, dpi, append):
     try:
-        file_out = get_output_filename(file_in, 'reduced')
+        file_out = get_output_filename(file_in, append)
         rutine = 'ghostscript -q  -dNOPAUSE -dBATCH -dSAFER \
         -sDEVICE=pdfwrite \
         -dCompatibilityLevel=1.4 \
@@ -270,12 +270,12 @@ def reduce_pdf(file_in):
         -dDownsampleColorImages=true \
         -dColorImageResolution=100 \
         -dColorImageDownsampleType=/Bicubic \
-        -dColorImageResolution=72 \
+        -dColorImageResolution="%s" \
         -dGrayImageDownsampleType=/Bicubic \
-        -dGrayImageResolution=72 \
+        -dGrayImageResolution="%s" \
         -dMonoImageDownsampleType=/Bicubic \
-        -dMonoImageResolution=72 \
-        -sOutputFile="%s" "%s"' % (file_out, file_in)
+        -dMonoImageResolution="%s" \
+        -sOutputFile="%s" "%s"' % (dpi, dpi, dpi, file_out, file_in)
         args = shlex.split(rutine)
         p = subprocess.Popen(args, stdout=subprocess.PIPE)
         out, err = p.communicate()
@@ -292,7 +292,7 @@ def get_output_filename(file_in, modificator):
     if os.path.exists(file_in) and os.path.isfile(file_in):
         head, tail = os.path.split(file_in)
         root, ext = os.path.splitext(tail)
-        file_out = os.path.join(head, root + '_' + modificator + ext)
+        file_out = os.path.join(head, root + modificator + ext)
         return file_out
     return None
 

--- a/src/pdf-tools/tools.py
+++ b/src/pdf-tools/tools.py
@@ -275,7 +275,7 @@ def reduce_pdf(file_in):
         -dGrayImageResolution=72 \
         -dMonoImageDownsampleType=/Bicubic \
         -dMonoImageResolution=72 \
-        -sOutputFile=%s %s' % (file_out, file_in)
+        -sOutputFile="%s" "%s"' % (file_out, file_in)
         args = shlex.split(rutine)
         p = subprocess.Popen(args, stdout=subprocess.PIPE)
         out, err = p.communicate()
@@ -350,7 +350,7 @@ def all_files_are_pdf(items):
     for item in items:
         fileName, fileExtension = os.path.splitext(
             unquote_plus(item.get_uri()[7:]))
-        if fileExtension != '.pdf':
+        if fileExtension.lower() != '.pdf':
             return False
     return True
 


### PR DESCRIPTION
1. At "Fix filename and file extension" I fixed problems with filenames which contain spaces, and fix problem with extension for example *.PDF.
2. At "Add window for reduce pdf with ability to set Image resolution and append to file" I added window for "Reduce pdf size" similar to window "Resize pdf pages" with ability to set Image resolution (default 100 dpi) and append for redued filename.
3. At "python-gi-cairo to Depends" I added python-gi-cairo instead of python-cairo to fix problem in "Split pdf files" or "Resize pdf pages" in ubuntu 16.04 and 18.04 (problem output: could not find foreign type Context)
4. I`ve tested on ubuntu 16.04 and 18.04 everything works fine.