### PR TITLE
Fixes and translation

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -41,7 +41,6 @@ msgid "Watermark"
 msgstr "Водяной знак"
 
 #: src/nautilus-pdf-tools.py:109
-#, fuzzy
 msgid "Watermark pdf files"
 msgstr "Водяной знак"
 
@@ -64,12 +63,11 @@ msgstr "Нумерация страниц"
 
 #: src/nautilus-pdf-tools.py:115 src/pdf-tools/signdialog.py:44
 msgid "Sign"
-msgstr ""
+msgstr "Подписать"
 
 #: src/nautilus-pdf-tools.py:115
-#, fuzzy
 msgid "Sign pdf files"
-msgstr "Объединить PDF-файлы"
+msgstr "Подписать PDF-файлы"
 
 #: src/nautilus-pdf-tools.py:121
 msgid "Remove pages"
@@ -158,54 +156,51 @@ msgstr "Конвертировать изображения в формате PD
 
 #: src/pdf-tools/basedialogwithapply.py:54
 msgid "Clear or apply to"
-msgstr ""
+msgstr "Отменить или применить к"
 
 #: src/pdf-tools/basedialogwithapply.py:56
 msgid "This page"
-msgstr ""
+msgstr "Эта страница"
 
 #: src/pdf-tools/basedialogwithapply.py:58
 msgid "All"
-msgstr ""
+msgstr "Все"
 
 #: src/pdf-tools/basedialogwithapply.py:63
 msgid "Range"
-msgstr ""
+msgstr "Страницы"
 
 #: src/pdf-tools/basedialogwithapply.py:71
 msgid "Clear"
-msgstr ""
+msgstr "Отменить"
 
 #: src/pdf-tools/basedialogwithapply.py:74
 msgid "Apply"
-msgstr ""
+msgstr "Применить"
 
 #: src/pdf-tools/basedialog.py:212 src/pdf-tools/basedialog.py:258
-#, fuzzy
 msgid "First page"
-msgstr "Извлечь страницы"
+msgstr "Первая страница"
 
 #: src/pdf-tools/basedialog.py:215 src/pdf-tools/basedialog.py:262
 msgid "Previous page"
-msgstr ""
+msgstr "Предыдущая страница"
 
 #: src/pdf-tools/basedialog.py:222 src/pdf-tools/basedialog.py:268
 msgid "Current_page"
-msgstr ""
+msgstr "Текущая_страница"
 
 #: src/pdf-tools/basedialog.py:226 src/pdf-tools/basedialog.py:272
-#, fuzzy
 msgid "Next page"
-msgstr "Извлечь страницы"
+msgstr "Следущая страница"
 
 #: src/pdf-tools/basedialog.py:230 src/pdf-tools/basedialog.py:276
-#, fuzzy
 msgid "Last page"
-msgstr "Повернуть страницы"
+msgstr "Последняя страница"
 
 #: src/pdf-tools/basedialog.py:237
 msgid "Options"
-msgstr ""
+msgstr "Параметры"
 
 #: src/pdf-tools/joinpdfsdialog.py:51
 #: src/pdf-tools/createpdffromImagesdialog.py:66
@@ -498,16 +493,15 @@ msgstr "Повернуть страницы"
 
 #: src/pdf-tools/flipdialog.py:95
 msgid "Flip"
-msgstr ""
+msgstr "Перевернуть"
 
 #: src/pdf-tools/flipdialog.py:105
 msgid "File name"
-msgstr ""
+msgstr "Имя файла"
 
 #: src/pdf-tools/flipdialog.py:107
-#, fuzzy
 msgid "Add to file"
-msgstr "Добавить к имени файла"
+msgstr "Добавить к файлу"
 
 #: src/pdf-tools/convertdialog.py:40 src/pdf-tools/convertdialog.py:50
 msgid "Convert to"
@@ -522,17 +516,16 @@ msgid "Text file"
 msgstr "Текстовый файл"
 
 #: src/pdf-tools/paginatedialog.py:81
-#, fuzzy
 msgid "Pagination"
 msgstr "Нумерация страниц"
 
 #: src/pdf-tools/paginatedialog.py:86 src/pdf-tools/textmarkdialog.py:94
 msgid "Font"
-msgstr ""
+msgstr "Шрифт"
 
 #: src/pdf-tools/paginatedialog.py:91 src/pdf-tools/textmarkdialog.py:99
 msgid "Color"
-msgstr ""
+msgstr "Цвет"
 
 #: src/pdf-tools/combinedialog.py:54
 msgid "Pages in Page"
@@ -636,7 +629,7 @@ msgstr "Добавить нумерацию"
 
 #: src/pdf-tools/pdfmanager.py:279
 msgid "Sign PDF"
-msgstr ""
+msgstr "Подписать PDF"
 
 #: src/pdf-tools/pdfmanager.py:303 src/pdf-tools/pdfmanager.py:310
 msgid "Remove PDF"
@@ -677,17 +670,16 @@ msgid "big margin"
 msgstr "Большие"
 
 #: src/pdf-tools/signdialog.py:71 src/pdf-tools/signdialog.py:83
-#, fuzzy
 msgid "Select signature file"
-msgstr "Выберите исходный файл"
+msgstr "Выберите файл"
 
 #: src/pdf-tools/signdialog.py:76 src/pdf-tools/signdialog.py:82
 msgid "Signature"
-msgstr ""
+msgstr "Подпись"
 
 #: src/pdf-tools/signdialog.py:78 src/pdf-tools/watermarkdialog.py:82
 msgid "Zoom"
-msgstr ""
+msgstr "Зум"
 
 #: src/pdf-tools/selectpagesdialog.py:49
 msgid "Pages"
@@ -704,9 +696,8 @@ msgstr ""
 "диапазоны, разделенные запятыми пр.1,4,6-9"
 
 #: src/pdf-tools/watermarkdialog.py:75 src/pdf-tools/watermarkdialog.py:87
-#, fuzzy
 msgid "Select watermark file"
-msgstr "Водяной знак"
+msgstr "Выберите файл"
 
 #: src/pdf-tools/watermarkdialog.py:124
 msgid "Select one image"

--- a/po/uk.po
+++ b/po/uk.po
@@ -41,7 +41,6 @@ msgid "Watermark"
 msgstr "Водяний знак"
 
 #: src/nautilus-pdf-tools.py:109
-#, fuzzy
 msgid "Watermark pdf files"
 msgstr "Водяний знак"
 
@@ -64,12 +63,11 @@ msgstr "Нумерація сторінок"
 
 #: src/nautilus-pdf-tools.py:115 src/pdf-tools/signdialog.py:44
 msgid "Sign"
-msgstr ""
+msgstr "Підписати"
 
 #: src/nautilus-pdf-tools.py:115
-#, fuzzy
 msgid "Sign pdf files"
-msgstr "Об'єднати PDF-файли"
+msgstr "Підписати PDF-файли"
 
 #: src/nautilus-pdf-tools.py:121
 msgid "Remove pages"
@@ -158,54 +156,51 @@ msgstr "Конвертувати зображення в PDF"
 
 #: src/pdf-tools/basedialogwithapply.py:54
 msgid "Clear or apply to"
-msgstr ""
+msgstr "Відхилити або застосувати до"
 
 #: src/pdf-tools/basedialogwithapply.py:56
 msgid "This page"
-msgstr ""
+msgstr "Поточна сторінка"
 
 #: src/pdf-tools/basedialogwithapply.py:58
 msgid "All"
-msgstr ""
+msgstr "Усі"
 
 #: src/pdf-tools/basedialogwithapply.py:63
 msgid "Range"
-msgstr ""
+msgstr "Сторінки:"
 
 #: src/pdf-tools/basedialogwithapply.py:71
 msgid "Clear"
-msgstr ""
+msgstr "Відхилити"
 
 #: src/pdf-tools/basedialogwithapply.py:74
 msgid "Apply"
-msgstr ""
+msgstr "Застосувати"
 
 #: src/pdf-tools/basedialog.py:212 src/pdf-tools/basedialog.py:258
-#, fuzzy
 msgid "First page"
-msgstr "Видобути сторінки"
+msgstr "Перша сторінка"
 
 #: src/pdf-tools/basedialog.py:215 src/pdf-tools/basedialog.py:262
 msgid "Previous page"
-msgstr ""
+msgstr "Попередня сторінка"
 
 #: src/pdf-tools/basedialog.py:222 src/pdf-tools/basedialog.py:268
 msgid "Current_page"
-msgstr ""
+msgstr "Поточна сторінка"
 
 #: src/pdf-tools/basedialog.py:226 src/pdf-tools/basedialog.py:272
-#, fuzzy
 msgid "Next page"
-msgstr "Видобути сторінки"
+msgstr "Наступна сторінка"
 
 #: src/pdf-tools/basedialog.py:230 src/pdf-tools/basedialog.py:276
-#, fuzzy
 msgid "Last page"
-msgstr "Повернути сторінки"
+msgstr "Остання сторінка"
 
 #: src/pdf-tools/basedialog.py:237
 msgid "Options"
-msgstr ""
+msgstr "Параметри"
 
 #: src/pdf-tools/joinpdfsdialog.py:51
 #: src/pdf-tools/createpdffromImagesdialog.py:66
@@ -498,16 +493,15 @@ msgstr "Повернути сторінки"
 
 #: src/pdf-tools/flipdialog.py:95
 msgid "Flip"
-msgstr ""
+msgstr "Перевернути"
 
 #: src/pdf-tools/flipdialog.py:105
 msgid "File name"
-msgstr ""
+msgstr "Ім'я файлу"
 
 #: src/pdf-tools/flipdialog.py:107
-#, fuzzy
 msgid "Add to file"
-msgstr "Додати до імені файлу"
+msgstr "Додати до файлу"
 
 #: src/pdf-tools/convertdialog.py:40 src/pdf-tools/convertdialog.py:50
 msgid "Convert to"
@@ -522,17 +516,16 @@ msgid "Text file"
 msgstr "Текстовий файл"
 
 #: src/pdf-tools/paginatedialog.py:81
-#, fuzzy
 msgid "Pagination"
 msgstr "Нумерація сторінок"
 
 #: src/pdf-tools/paginatedialog.py:86 src/pdf-tools/textmarkdialog.py:94
 msgid "Font"
-msgstr ""
+msgstr "Шрифт"
 
 #: src/pdf-tools/paginatedialog.py:91 src/pdf-tools/textmarkdialog.py:99
 msgid "Color"
-msgstr ""
+msgstr "Колір"
 
 #: src/pdf-tools/combinedialog.py:54
 msgid "Pages in Page"
@@ -636,7 +629,7 @@ msgstr "Додати нумерацію сторінок"
 
 #: src/pdf-tools/pdfmanager.py:279
 msgid "Sign PDF"
-msgstr ""
+msgstr "Підписати PDF"
 
 #: src/pdf-tools/pdfmanager.py:303 src/pdf-tools/pdfmanager.py:310
 msgid "Remove PDF"
@@ -677,17 +670,16 @@ msgid "big margin"
 msgstr "Великі поля"
 
 #: src/pdf-tools/signdialog.py:71 src/pdf-tools/signdialog.py:83
-#, fuzzy
 msgid "Select signature file"
-msgstr "Виберіть вихідний файл"
+msgstr "Вибрати файл"
 
 #: src/pdf-tools/signdialog.py:76 src/pdf-tools/signdialog.py:82
 msgid "Signature"
-msgstr ""
+msgstr "Підпис"
 
 #: src/pdf-tools/signdialog.py:78 src/pdf-tools/watermarkdialog.py:82
 msgid "Zoom"
-msgstr ""
+msgstr "Масштаб"
 
 #: src/pdf-tools/selectpagesdialog.py:49
 msgid "Pages"
@@ -704,9 +696,8 @@ msgstr ""
 "діапазони,розділені комами пр.1,4,6-9 "
 
 #: src/pdf-tools/watermarkdialog.py:75 src/pdf-tools/watermarkdialog.py:87
-#, fuzzy
 msgid "Select watermark file"
-msgstr "Водяний знак"
+msgstr "Вибрати файл"
 
 #: src/pdf-tools/watermarkdialog.py:124
 msgid "Select one image"

--- a/src/pdf-tools/basedialog.py
+++ b/src/pdf-tools/basedialog.py
@@ -160,7 +160,7 @@ class BaseDialog(BasicDialog):
         BasicDialog.init_ui(self)
 
         self.scrolledwindow1 = Gtk.ScrolledWindow()
-        self.scrolledwindow1.set_size_request(630, 630)
+        self.scrolledwindow1.set_size_request(629, 629)
         self.grid.attach(self.scrolledwindow1, 0, 0, 1, 1)
 
         self.viewport1 = MiniView()

--- a/src/pdf-tools/paginatedialog.py
+++ b/src/pdf-tools/paginatedialog.py
@@ -97,8 +97,8 @@ class PaginateDialog(TextmarkDialog):
         color = self.button_color.get_rgba()
         font = self.button_font.get_font()
         size = int(self.button_font.get_font_desc().get_size()/1000)
-        x = self.x
-        y = self.y
+        x = self.x+20
+        y = self.y+15
         if self.check_this.get_active():
             to_update = [self.no_page]
         elif self.check_all.get_active():
@@ -126,7 +126,7 @@ class PaginateDialog(TextmarkDialog):
         size = int(self.button_font.get_font_desc().get_size()/1000)
         self.viewport1.set_page_options(PageOptions(text_text=text,
                     text_color=color, text_font=font, text_size=size,
-                    text_x=self.x, text_y=self.y))
+                    text_x=self.x+20, text_y=self.y+15))
 
     def on_viewport1_clicked(self, widget, event):
         deltay = abs(self.viewport1.get_allocation().height -

--- a/src/pdf-tools/textmarkdialog.py
+++ b/src/pdf-tools/textmarkdialog.py
@@ -109,8 +109,8 @@ class TextmarkDialog(BaseDialogWithApply):
         color = self.button_color.get_rgba()
         font = self.button_font.get_font()
         size = int(self.button_font.get_font_desc().get_size()/1000)
-        x = self.x
-        y = self.y
+        x = self.x+20
+        y = self.y+15
         if self.check_this.get_active():
             to_update = [ self.no_page]
         elif self.check_all.get_active():
@@ -135,7 +135,7 @@ class TextmarkDialog(BaseDialogWithApply):
         size = int(self.button_font.get_font_desc().get_size()/1000)
         self.viewport1.set_page_options(PageOptions(text_text=text,
                     text_color=color, text_font=font, text_size=size,
-                    text_x=self.x, text_y=self.y))
+                    text_x=self.x+20, text_y=self.y+15))
 
     def on_viewport1_clicked(self, widget, event):
         deltay = abs(self.viewport1.get_allocation().height -

--- a/src/pdf-tools/watermarkdialog.py
+++ b/src/pdf-tools/watermarkdialog.py
@@ -117,7 +117,7 @@ class WatermarkDialog(BaseDialogWithApply):
         if not os.path.exists(file_watermark):
             file_watermark = None
         self.viewport1.set_page_options(PageOptions(
-            image_x=self.x, image_y=self.y, image_zoom=zoom,
+            image_x=self.x+20, image_y=self.y+15, image_zoom=zoom,
             image_file=file_watermark))
 
     def on_button_watermark_clicked(self, button):


### PR DESCRIPTION
In "Fix Options window opens too slow in big file" commit, I have fixed a problem when for example I open pdf file with one page size is 1.1Mb than I notice that Options window opens and hides too slow. In small size pdf files problem does not appear. This fixes problem with big pages size.

In "Fix bad placement on page" commit, I have fixed pagination... placement on page. When I press Apply button pagination appears to high on page which makes it invisible on A4 page. Attached file displays problem.
![Знімок екрана з 2021-11-26 14-52-26](https://user-images.githubusercontent.com/20279809/143584033-33f21fba-db6b-41ab-ba29-2b5ff4ab7190.png)

In "Update uk and ru translation" I have only update Ukrainian and Russian translation.